### PR TITLE
fix: don't cache failed composer runs as "no vulnerabilities", enforce ACL, raise timeout

### DIFF
--- a/src/Controller/Adminhtml/Audit/Index.php
+++ b/src/Controller/Adminhtml/Audit/Index.php
@@ -2,16 +2,27 @@
 
 namespace Corrivate\ComposerDashboard\Controller\Adminhtml\Audit;
 
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\View\Result\PageFactory;
 
-class Index implements HttpGetActionInterface
+/**
+ * Extends Backend\App\Action on purpose: ADMIN_RESOURCE is only ever read by
+ * AbstractAction::_isAllowed(), and the adminAuthentication / secret-key checks are
+ * plugins bound to Magento\Backend\App\AbstractAction. A controller that merely
+ * implements HttpGetActionInterface is reached without any of them.
+ */
+class Index extends Action implements HttpGetActionInterface
 {
     public const ADMIN_RESOURCE = 'Corrivate_ComposerDashboard::composerdashboard';
 
-    public function __construct(private readonly PageFactory $resultPageFactory)
-    {
+    public function __construct(
+        Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
     }
 
     public function execute(): ResultInterface
@@ -24,4 +35,3 @@ class Index implements HttpGetActionInterface
         return $resultPage;
     }
 }
-

--- a/src/Controller/Adminhtml/Installed/Index.php
+++ b/src/Controller/Adminhtml/Installed/Index.php
@@ -2,16 +2,27 @@
 
 namespace Corrivate\ComposerDashboard\Controller\Adminhtml\Installed;
 
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\View\Result\PageFactory;
 
-class Index implements HttpGetActionInterface
+/**
+ * Extends Backend\App\Action on purpose: ADMIN_RESOURCE is only ever read by
+ * AbstractAction::_isAllowed(), and the adminAuthentication / secret-key checks are
+ * plugins bound to Magento\Backend\App\AbstractAction. A controller that merely
+ * implements HttpGetActionInterface is reached without any of them.
+ */
+class Index extends Action implements HttpGetActionInterface
 {
     public const ADMIN_RESOURCE = 'Corrivate_ComposerDashboard::composerdashboard';
 
-    public function __construct(private readonly PageFactory $resultPageFactory)
-    {
+    public function __construct(
+        Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
     }
 
     public function execute(): ResultInterface
@@ -24,4 +35,3 @@ class Index implements HttpGetActionInterface
         return $resultPage;
     }
 }
-

--- a/src/Cron/WarmCache.php
+++ b/src/Cron/WarmCache.php
@@ -5,13 +5,16 @@ namespace Corrivate\ComposerDashboard\Cron;
 use Corrivate\ComposerDashboard\Model\Composer\Audit;
 use Corrivate\ComposerDashboard\Model\Composer\InstalledPackages;
 use Corrivate\ComposerDashboard\Model\Config\Settings;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
 class WarmCache
 {
     public function __construct(
         private readonly Audit             $audit,
         private readonly InstalledPackages $installedPackages,
-        private readonly Settings          $settings
+        private readonly Settings          $settings,
+        private readonly LoggerInterface   $logger
     ) {
     }
 
@@ -20,7 +23,16 @@ class WarmCache
         if (!$this->settings->warmCache()) {
             return;
         }
-        $this->audit->getRows();
-        $this->installedPackages->getRows();
+
+        // Log and rethrow: the message lands in the log file, and the rethrow marks the
+        // cron job as errored, so a broken composer setup is visible in both places
+        // instead of silently leaving the dashboard empty.
+        try {
+            $this->audit->getRows();
+            $this->installedPackages->getRows();
+        } catch (Throwable $e) {
+            $this->logger->error('Composer Dashboard cache warming failed: ' . $e->getMessage(), ['exception' => $e]);
+            throw $e;
+        }
     }
 }

--- a/src/Model/Composer/Audit.php
+++ b/src/Model/Composer/Audit.php
@@ -7,10 +7,17 @@ use Corrivate\ComposerDashboard\Model\Cache\ComposerCache;
 use Corrivate\ComposerDashboard\Model\Config\Settings;
 use Corrivate\ComposerDashboard\Model\Value\AuditIssue;
 use Magento\Framework\Exception\LocalizedException;
+use RuntimeException;
 use Symfony\Component\Process\Process;
 
 class Audit implements AuditInterface
 {
+    /**
+     * Composer contacts every configured repository; on a large installation that
+     * takes minutes. Symfony's default timeout of 60 seconds is far too low.
+     */
+    private const TIMEOUT = 900;
+
     public function __construct(
         private readonly ComposerCache $cache,
         private readonly Settings      $settings
@@ -24,6 +31,7 @@ class Audit implements AuditInterface
         $issues = $this->cache->loadIssues();
 
         if ($issues === null || $forceRefresh) {
+            // Not caught on purpose: a failed run must never be cached as "no issues".
             $issues = $this->getFromComposer();
             $this->cache->saveIssues($issues);
         }
@@ -34,32 +42,69 @@ class Audit implements AuditInterface
     /** @return AuditIssue[] */
     private function getFromComposer(): array
     {
-        $command = 'vendor/bin/composer audit --format=json --abandoned=ignore';
-
-        $process = new Process(explode(' ', $command));
+        $process = new Process([
+            'vendor/bin/composer',
+            'audit',
+            '--format=json',
+            '--abandoned=ignore',
+            '--no-interaction',
+            '--no-plugins',
+            '--no-scripts',
+        ]);
         $process->setWorkingDirectory(BP); // @phpstan-ignore constant.notFound
+        $process->setTimeout(self::TIMEOUT);
         $process->run();
 
-        $output = $process->getOutput();
-        $json = json_decode($output, true);
-        $advisories = $json['advisories'] ?? [];
+        $json = json_decode($process->getOutput(), true);
+
+        // `composer audit` exits 1 both when advisories are found and when it fails,
+        // so success is decided by the shape of the output, not by the exit code.
+        if (!is_array($json) || !array_key_exists('advisories', $json)) {
+            throw new RuntimeException(sprintf(
+                'composer audit failed (exit code %s): %s',
+                var_export($process->getExitCode(), true),
+                trim($process->getErrorOutput()) ?: 'no error output'
+            ));
+        }
+
+        $advisories = is_array($json['advisories']) ? $json['advisories'] : [];
 
         $rows = [];
         foreach ($advisories as $package => $issues) {
+            if (!is_array($issues)) {
+                continue;
+            }
             foreach ($issues as $issue) {
                 $rows[] = new AuditIssue(
-                    package: $package,
-                    title: $issue['title'] ?? '(no title)',
-                    cve: $issue['cve'] ?? 'unknown',
-                    link: $issue['link'] ?? '',
-                    severity: $this->matchSeverity($issue['severity'] ?? 'unknown'),
-                    severity_original: $issue['severity'] ?? 'unknown',
-                    reported: (new \DateTime($issue['reportedAt']))->format('Y-m-d H:i:s')
+                    package: (string)$package,
+                    title: (string)($issue['title'] ?? '(no title)'),
+                    cve: (string)($issue['cve'] ?? 'unknown'),
+                    link: (string)($issue['link'] ?? ''),
+                    severity: $this->matchSeverity((string)($issue['severity'] ?? 'unknown')),
+                    severity_original: (string)($issue['severity'] ?? 'unknown'),
+                    reported: $this->formatReportedAt($issue['reportedAt'] ?? null)
                 );
             }
         }
 
         return $rows;
+    }
+
+    /**
+     * `reportedAt` is absent from some advisory sources, and `cve` is explicitly null
+     * for GitHub-only advisories, so neither may be passed to DateTime unguarded.
+     */
+    private function formatReportedAt(mixed $reportedAt): string
+    {
+        if (!is_string($reportedAt) || $reportedAt === '') {
+            return '';
+        }
+
+        try {
+            return (new \DateTime($reportedAt))->format('Y-m-d H:i:s');
+        } catch (\Exception) {
+            return '';
+        }
     }
 
     private function matchSeverity(string $severity): int

--- a/src/Model/Composer/InstalledPackages.php
+++ b/src/Model/Composer/InstalledPackages.php
@@ -7,10 +7,18 @@ use Corrivate\ComposerDashboard\Model\Cache\ComposerCache;
 use Corrivate\ComposerDashboard\Model\Config\Settings;
 use Corrivate\ComposerDashboard\Model\Value\InstalledPackage;
 use Magento\Framework\Exception\LocalizedException;
+use RuntimeException;
 use Symfony\Component\Process\Process;
 
 class InstalledPackages implements InstalledPackagesInterface
 {
+    /**
+     * `show --latest` queries every configured repository. Measured at 149s on an
+     * installation with ~690 packages across 15 repositories; the Symfony default of
+     * 60s guarantees a ProcessTimedOutException there.
+     */
+    private const TIMEOUT = 900;
+
     public function __construct(
         private readonly ComposerCache $cache,
         private readonly Settings      $settings
@@ -23,6 +31,7 @@ class InstalledPackages implements InstalledPackagesInterface
         $rows = $this->cache->loadInstalledPackages();
 
         if ($rows === null || $forceFresh) {
+            // Not caught on purpose: a failed run must never be cached as an empty list.
             $rows = $this->getFromComposer();
             $this->cache->saveInstalledPackages($rows);
         }
@@ -33,36 +42,59 @@ class InstalledPackages implements InstalledPackagesInterface
     /** @return InstalledPackage[] */
     private function getFromComposer(): array
     {
-        $command = 'vendor/bin/composer show --format=json --no-dev --latest';
-
-        $process = new Process(explode(' ', $command));
+        $process = new Process([
+            'vendor/bin/composer',
+            'show',
+            '--format=json',
+            '--no-dev',
+            '--latest',
+            '--no-interaction',
+            '--no-plugins',
+            '--no-scripts',
+        ]);
         $process->setWorkingDirectory(BP); // @phpstan-ignore constant.notFound
+        $process->setTimeout(self::TIMEOUT);
         $process->run();
 
-        $output = $process->getOutput();
-        $json = json_decode($output, true);
-        $packages = $json['installed'] ?? [];
+        $json = json_decode($process->getOutput(), true);
+
+        // A failed run produces empty stdout, which must be told apart from a
+        // successful run: silently returning [] would be cached as "nothing installed".
+        if (!is_array($json) || !array_key_exists('installed', $json)) {
+            throw new RuntimeException(sprintf(
+                'composer show failed (exit code %s): %s',
+                var_export($process->getExitCode(), true),
+                trim($process->getErrorOutput()) ?: 'no error output'
+            ));
+        }
+
+        $packages = is_array($json['installed']) ? $json['installed'] : [];
 
         $rows = [];
         foreach ($packages as $package) {
-            if ($package['name'] === 'magento/product-community-edition') {
-                $package['latest-status'] = $this->checkMagentoVersion($package['version'], $package['latest']);
+            if (($package['name'] ?? null) === 'magento/product-community-edition') {
+                $package['latest-status'] = $this->checkMagentoVersion(
+                    (string)$package['version'],
+                    (string)$package['latest']
+                );
             }
 
+            // `abandoned` is `true` OR the replacement package name (ShowCommand.php),
+            // so it must be cast rather than passed straight into a bool parameter.
             $install = new InstalledPackage(
-                package: $package['name'],
-                direct: $package['direct-dependency'],
-                homepage: $package['homepage'] ?? '',
-                source: $package['source'] ?? '',
-                version: $package['version'],
-                release_age: $package['release-age'],
-                release_date: $package['release-date'],
-                latest: $package['latest'],
-                latest_status: $package['latest-status'],
-                latest_release_date: $package['latest-release-date'] ?? '',
-                description: $package['description'] ?? '',
-                abandoned: $package['abandoned'],
-                semver_status: $this->semverCodeFromComposer($package['latest-status'])
+                package: (string)$package['name'],
+                direct: (bool)($package['direct-dependency'] ?? false),
+                homepage: (string)($package['homepage'] ?? ''),
+                source: (string)($package['source'] ?? ''),
+                version: (string)$package['version'],
+                release_age: (string)($package['release-age'] ?? ''),
+                release_date: (string)($package['release-date'] ?? ''),
+                latest: (string)($package['latest'] ?? ''),
+                latest_status: (string)($package['latest-status'] ?? 'unknown'),
+                latest_release_date: (string)($package['latest-release-date'] ?? ''),
+                description: (string)($package['description'] ?? ''),
+                abandoned: (bool)($package['abandoned'] ?? false),
+                semver_status: $this->semverCodeFromComposer((string)($package['latest-status'] ?? 'unknown'))
             );
 
             $rows[] = $install;
@@ -77,10 +109,16 @@ class InstalledPackages implements InstalledPackagesInterface
         }
 
         // Split the version tags into a #.#.# version part and optional -p# part
-        preg_match('/^(\d+\.\d+\.\d+)(?:-(p\d+))?$/', $current, $currentParts);
-        preg_match('/^(\d+\.\d+\.\d+)(?:-(p\d+))?$/', $latest, $latestParts);
+        $currentMatched = preg_match('/^(\d+\.\d+\.\d+)(?:-(p\d+))?$/', $current, $currentParts);
+        $latestMatched = preg_match('/^(\d+\.\d+\.\d+)(?:-(p\d+))?$/', $latest, $latestParts);
 
-        if ($currentParts[1] != $latestParts[1]) { // @phpstan-ignore offsetAccess.notFound, offsetAccess.notFound
+        // Pre-release tags such as 2.4.9-beta1 do not match; without this guard the
+        // reads below emit "Undefined array key 1" warnings and compare null to null.
+        if ($currentMatched !== 1 || $latestMatched !== 1) {
+            return 'unknown';
+        }
+
+        if ($currentParts[1] != $latestParts[1]) {
             // Then this is more than a patch-level difference and needs significant testing during upgrade
             return 'update-possible';
         }

--- a/src/Model/Config/Settings.php
+++ b/src/Model/Config/Settings.php
@@ -70,7 +70,10 @@ class Settings
     public function getIgnoredAdvisories(): array
     {
         $value = (string)$this->scopeConfig->getValue(self::XPATH_ADVISORY_IGNORED_PACKAGES);
-        $value = str_replace("\n", "", $value);
+        // Strip CR only: the field is a textarea documented as "Separate with newlines",
+        // and browsers submit CRLF. Stripping LF (as before) glued the whole list into
+        // a single entry, so no package was ever ignored.
+        $value = str_replace("\r", "", $value);
         $value = str_replace(",", "\n", $value);
         $items = explode("\n", $value);
         $items = array_map(fn ($item) => trim($item), $items);

--- a/src/Model/System/Message/AuditIssues.php
+++ b/src/Model/System/Message/AuditIssues.php
@@ -47,10 +47,18 @@ class AuditIssues implements \Magento\Framework\Notification\MessageInterface
     public function getSeverity(): int
     {
         // What is the worst current issue?
-        $severity = (int)min(array_map(
+        $severities = array_map(
             fn (AuditIssue $a) => $a->severity,
             $this->composerCache->loadIssues() ?? []
-        ));
+        );
+
+        // min() throws a ValueError on an empty array in PHP 8. Magento only calls this
+        // after isDisplayed(), but the cache can be flushed between the two calls.
+        if ($severities === []) {
+            return MessageInterface::SEVERITY_NOTICE;
+        }
+
+        $severity = (int)min($severities);
 
         // Translate to Magento severity levels
         return match($severity) {

--- a/src/etc/crontab.xml
+++ b/src/etc/crontab.xml
@@ -2,9 +2,15 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="default">
+        <!--
+            Every 15 minutes rather than every minute. The cache lives for 24h, so a
+            per-minute schedule adds 1440 rows/day to cron_schedule for at most one
+            useful run, and after a cache flush it retries a multi-minute composer call
+            every single minute until it succeeds.
+        -->
         <job name="corrivate_composerdashboard_warm_cache" instance="Corrivate\ComposerDashboard\Cron\WarmCache"
              method="execute">
-            <schedule>* * * * *</schedule>
+            <schedule>*/15 * * * *</schedule>
         </job>
         <job name="corrivate_composerdashboard_send_advisory_reminders"
              instance="Corrivate\ComposerDashboard\Cron\SendAdvisoryReminders" method="execute">

--- a/src/view/adminhtml/templates/email/advisories.phtml
+++ b/src/view/adminhtml/templates/email/advisories.phtml
@@ -1,7 +1,7 @@
 <?php
 
-/** @var \Corrivate\ComposerDashboard\Block\Adminhtml\Email\Advisories $block
- */
+/** @var \Corrivate\ComposerDashboard\Block\Adminhtml\Email\Advisories $block */
+/** @var \Magento\Framework\Escaper $escaper */
 
 use Corrivate\ComposerDashboard\Model\Value\AuditIssue;
 
@@ -9,8 +9,8 @@ use Corrivate\ComposerDashboard\Model\Value\AuditIssue;
 
 <?php foreach ($block->getAdvisories() as $advisory): ?>
     <tr style="font-size:14px;">
-        <td><?= $advisory->package ?></td>
-        <td><?= $advisory->cve ?></td>
+        <td><?= $escaper->escapeHtml($advisory->package) ?></td>
+        <td><?= $escaper->escapeHtml($advisory->cve) ?></td>
         <?php if($advisory->severity >= AuditIssue::SEVERITY_MEDIUM): ?>
             <td><?= AuditIssue::SEVERITY_LABELS[$advisory->severity] ?></td>
         <?php else: ?>

--- a/src/view/adminhtml/templates/email/outdated.phtml
+++ b/src/view/adminhtml/templates/email/outdated.phtml
@@ -9,9 +9,9 @@ use Corrivate\ComposerDashboard\Model\Value\InstalledPackage;
 
 <?php foreach ($block->getOutdated() as $package): ?>
     <tr>
-        <td><?= $package->package ?></td>
-        <td style="text-align: right"><?= $package->version ?></td>
-        <td style="text-align: right"><?= $package->latest ?></td>
+        <td><?= $escaper->escapeHtml($package->package) ?></td>
+        <td style="text-align: right"><?= $escaper->escapeHtml($package->version) ?></td>
+        <td style="text-align: right"><?= $escaper->escapeHtml($package->latest) ?></td>
         <td style="text-align: right"><?= InstalledPackage::SEMVER_LABELS[$package->semver_status] ?? 'unknown' ?></td>
         <?php if($package->abandoned): ?>
             <td style="padding-left:10px;"><b>abandoned</b></td>

--- a/src/view/adminhtml/templates/grid/cell/package-name.phtml
+++ b/src/view/adminhtml/templates/grid/cell/package-name.phtml
@@ -11,8 +11,8 @@ $parts = explode(' ', $block->getValue(), 2)
 
 ?>
 
-<span><?= $parts[0]?></span>
+<span><?= $escaper->escapeHtml($parts[0]) ?></span>
 <?php if(count($parts) == 2): ?>
 <br/>
-<span><?= $parts[1]?></span>
+<span><?= $escaper->escapeHtml($parts[1]) ?></span>
 <?php endif; ?>


### PR DESCRIPTION
Hi Lau — thanks for this module, the idea of surfacing `composer audit` where a PM can actually see it is a good one.

I evaluated it for a Magento Open Source 2.4.8-p5 shop (~690 production packages, 15 repositories, Composer 2.10.2, PHP 8.3) and hit a few things while reading the code. Everything below was reproduced on that installation before being changed, and the result passes `setup:di:compile`.

## 1. A failed composer call is cached as "no vulnerabilities"

This is the one that worried me most, because it fails silently in the safe-looking direction.

`Audit::getFromComposer()` ignores the result of `$process->run()`. When composer fails, stdout is empty:

```
exit code      : 127
isSuccessful() : false
stdout         : ""
stderr         : "sh: 1: exec: vendor/bin/composer: not found"
json_decode    : NULL
module gets    : []      <- cached for 24h as a valid result
```

The dashboard then shows "no advisories", the system message stays hidden, no reminder mail goes out, and nothing is logged — `Model/Composer/` has no logger and no try/catch. Realistic triggers on a production box: php-fpm with `clear_env = yes` (composer aborts because `HOME` is unset), a 401 from a private repository, a VCS repository unreachable for the web user, or no outbound network.

The exit code cannot be used to detect this, which I think is the reason it was never caught:

| situation | exit code | stdout |
|---|---|---|
| advisories found | **1** | valid JSON |
| no advisories | 0 | valid JSON |
| composer failed | **1** | empty |

So `isSuccessful()` would break the module for everyone who actually has an advisory. Instead this PR keys on the shape of the output — a successful run always has the `advisories` (resp. `installed`) key — and throws when it is missing, before anything reaches the cache.

## 2. The 60-second default timeout is always exceeded

`Process` defaults to `timeout = 60` and `setTimeout()` is never called. Measured on the installation above with a cold metadata cache:

```
composer show --format=json --no-dev --latest   ->  149 seconds
```

So `ProcessTimedOutException` is the normal outcome, not an edge case. Combined with the per-minute warm-up cron, that means a multi-minute composer process starting every minute after each `cache:flush`. This PR sets 900s and moves the cron to `*/15`.

## 3. `ADMIN_RESOURCE` on the controllers has no effect

Both controllers declare `ADMIN_RESOURCE` but only `implements HttpGetActionInterface`. That constant is read in exactly one place in the whole framework — `Magento\Backend\App\AbstractAction::_isAllowed()` — and `adminAuthentication` / `adminLoadDesign` / the secret-key check are plugins bound to `Magento\Backend\App\AbstractAction` (`module-backend/etc/adminhtml/di.xml`). A controller that does not extend it never goes through any of them.

I checked the whole `vendor/magento` tree: of the adminhtml controllers there, none use `implements Http*ActionInterface` without also extending the backend action. Extending `Magento\Backend\App\Action` restores the check; narrowing `execute()` to `ResultInterface` remains valid because `ActionInterface::execute()` declares no return type.

## 4. The advisory ignore-list never matched anything

`getIgnoredAdvisories()` strips `"\n"` before splitting on newlines, while the field is a textarea whose comment says "Separate with newlines" and browsers submit CRLF:

```
input                          "vendor/a\r\nvendor/b\r\nvendor/c"
getIgnoredAdvisories()   ->    ["vendor/a\rvendor/b\rvendor/c"]     one bogus entry
getIgnoredOutdated()     ->    ["vendor/a","vendor/b","vendor/c"]   correct
```

The sibling method strips `"\r"`, which is right. Looks like a copy-paste slip. After the change, newline / comma / mixed input all parse.

## Smaller items in the same pass

- `getSeverity()` calls `min()` on a possibly empty array → `ValueError` on PHP 8. Guarded, since the cache can be flushed between `isDisplayed()` and `getSeverity()`.
- `checkMagentoVersion()` reads `$currentParts[1]` without checking `preg_match`. `2.4.9-beta1` and `dev-main` do not match, giving "Undefined array key 1"; now returns `unknown`.
- `abandoned` is `true` **or the replacement package name** (`ShowCommand.php:598`), so it can be a string reaching a `bool` parameter. Currently survives only because the file has no `declare(strict_types=1)`. Fields are cast explicitly now.
- `reportedAt` is passed to `DateTime` unguarded; it is absent from some advisory sources.
- `--no-interaction --no-plugins --no-scripts` added: the call runs from a web request, where a prompt hangs the request and project plugins (root-update, dependency-audit) should not execute as the web user.
- Escaped package names / CVE ids / versions in the grid cell and both mail templates — reachable only via a malicious dependency, but it trips `Magento2.Security.XssTemplate`.

## Notes

- Rebased on `main`, no conflicts with `d06b35d`.
- Three separate commits, each independently reviewable — happy to split or drop any of them.
- I deliberately did **not** touch the cache TTL, the Loki dependency or anything architectural.
- The thrown exception surfaces as an error in the grid rather than a silent empty table. If you would rather show a friendly message instead, say the word and I will add one — I kept it loud on purpose, since I think a security dashboard confidently reporting "all clear" while broken is the worse failure mode.
- Issue #3 asked for exactly this ("it should log the error it got"); this covers the logging half of it.

Happy to adjust anything to your taste.

🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code); every claim in it was reproduced on a real installation before being written.
